### PR TITLE
Fix incorrectly binding a preventDefault on document

### DIFF
--- a/src/js/component/auto_complete.js
+++ b/src/js/component/auto_complete.js
@@ -83,7 +83,7 @@ define([
       self.clear();
     });
 
-    $(document).on('keydown', function(event) {
+    $(self.container).on('keydown', function(event) {
       switch (event.keyCode) {
 
         case KEY_CODE.escape:

--- a/test/specs/component/autocompleteSpec.js
+++ b/test/specs/component/autocompleteSpec.js
@@ -84,14 +84,14 @@ define([
       it('for the escape key', function() {
         var stub = sinon.stub(autoComplete, 'escapeKeyHandler');
         var event = $.Event('keydown', { keyCode: 27 });
-        $(document).trigger(event);
+        $(container).trigger(event);
         expect(stub.calledOnce).toBe(true);
         stub.restore();
       });
       it('for the enter key', function() {
         var stub = sinon.stub(autoComplete, 'enterKeyHandler');
         var event = $.Event('keydown', { keyCode: 13 });
-        $(document).trigger(event);
+        $(container).trigger(event);
         expect(stub.calledOnce).toBe(true);
         stub.restore();
       });
@@ -99,7 +99,7 @@ define([
       it('for the up arrow', function() {
         var stub = sinon.stub(autoComplete, 'highlightPrevSearchResult');
         var event = $.Event('keydown', { keyCode: 38 });
-        $(document).trigger(event);
+        $(container).trigger(event);
         expect(stub.calledOnce).toBe(true);
         stub.restore();
       });
@@ -107,7 +107,7 @@ define([
       it('for the down arrow', function() {
         var stub = sinon.stub(autoComplete, 'highlightNextSearchResult');
         var event = $.Event('keydown', { keyCode: 40 });
-        $(document).trigger(event);
+        $(container).trigger(event);
         expect(stub.calledOnce).toBe(true);
         stub.restore();
       });


### PR DESCRIPTION
The auto-complete component was binding to the document keydown event that issued a preventDefault on ArrowUp.

This broke keyboard scrolling on any pages implementing it (m.bbc.co.uk & travel exhibit this)

This fix binds these events to the autocomplete container.